### PR TITLE
Fix anisotropic tensor convolution naming

### DIFF
--- a/rcwa/core/adapters.py
+++ b/rcwa/core/adapters.py
@@ -37,7 +37,8 @@ class TensorToConvolutionAdapter:
         
         For uniform layers (no spatial variation), this creates convolution matrices
         where all 9 tensor components are represented as diagonal matrices scaled by
-        the respective tensor element.
+        the respective tensor element. The returned dictionary uses the project-wide
+        `er_ij`/`ur_ij` naming convention for electric and magnetic tensor components.
         
         :param epsilon_tensor: 3x3 complex permittivity tensor
         :param mu_tensor: 3x3 complex permeability tensor  
@@ -61,17 +62,22 @@ class TensorToConvolutionAdapter:
         # For uniform layers, each tensor component becomes a scaled identity matrix
         convolution_matrices = {}
         
-        # Epsilon tensor components
+        # Permittivity tensor components (use er_ prefix for project-wide consistency)
+        axes = ["x", "y", "z"]
         for i in range(3):
             for j in range(3):
-                component_name = f'eps_{["x", "y", "z"][i]}{["x", "y", "z"][j]}'
-                convolution_matrices[component_name] = epsilon_tensor[i, j] * complexIdentity(matrix_dim)
-        
-        # Mu tensor components  
+                component_name = f'er_{axes[i]}{axes[j]}'
+                convolution_matrices[component_name] = (
+                    epsilon_tensor[i, j] * complexIdentity(matrix_dim)
+                )
+
+        # Permeability tensor components (use ur_ prefix)
         for i in range(3):
             for j in range(3):
-                component_name = f'mu_{["x", "y", "z"][i]}{["x", "y", "z"][j]}'
-                convolution_matrices[component_name] = mu_tensor[i, j] * complexIdentity(matrix_dim)
+                component_name = f'ur_{axes[i]}{axes[j]}'
+                convolution_matrices[component_name] = (
+                    mu_tensor[i, j] * complexIdentity(matrix_dim)
+                )
         
         return convolution_matrices
     

--- a/tests/test_tensor_solver_integration.py
+++ b/tests/test_tensor_solver_integration.py
@@ -36,14 +36,14 @@ class TestTensorAdapters:
         
         # Should generate 18 matrices (9 for eps, 9 for mu)
         assert len(result) == 18
-        
-        # Check specific tensor components
-        assert result['eps_xx'] == (2.0+0j)
-        assert result['eps_yy'] == (3.0+0j) 
-        assert result['eps_zz'] == (4.0+0j)
-        assert result['mu_xx'] == (1.0+0j)
-        assert result['mu_yy'] == (1.0+0j)
-        assert result['mu_zz'] == (1.0+0j)
+
+        # Check specific tensor components (using er_/ur_ naming)
+        assert result['er_xx'] == (2.0+0j)
+        assert result['er_yy'] == (3.0+0j)
+        assert result['er_zz'] == (4.0+0j)
+        assert result['ur_xx'] == (1.0+0j)
+        assert result['ur_yy'] == (1.0+0j)
+        assert result['ur_zz'] == (1.0+0j)
     
     def test_extract_effective_properties(self, basic_tensors):
         """Test extraction of effective scalar properties."""


### PR DESCRIPTION
## Summary
- Output convolution matrices for tensor materials using `er_ij`/`ur_ij` names
- Store full tensor convolution matrices in `Layer.set_convolution_matrices`
- Align adapter tests with new naming convention

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b12723c860832783820c4a1319334e