### PR TITLE
feat: add wavelength dependent refractive index

### DIFF
--- a/tests/test_anisotropic_integration.py
+++ b/tests/test_anisotropic_integration.py
@@ -4,7 +4,14 @@ Integration tests for anisotropic materials with Fresnel equation validation
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose
-from rcwa import TensorMaterial, Layer, LayerStack, Source, Solver
+import sys, os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from rcwa.model.material import TensorMaterial
+from rcwa.model.layer import Layer, LayerStack
+from rcwa.solve.source import Source
+from rcwa.core.solver import Solver
 from rcwa.utils import rTE, rTM
 
 

--- a/tests/test_material.py
+++ b/tests/test_material.py
@@ -1,7 +1,12 @@
 import pytest
 import os
 import numpy as np
-from rcwa import Material, Source
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from rcwa.model.material import Material
+from rcwa.solve.source import Source
 from rcwa.testing import *
 from rcwa.shorthand import *
 
@@ -198,3 +203,21 @@ def test_dispersive_func_ur():
     mat = Material(er=3, ur=lambda x: x, source=src)
     assert mat.er == 3
     assert mat.ur == 0.1
+
+
+@pytest.mark.unit
+def test_wavelength_dependent_n():
+    src = Source(wavelength=1.0)
+    n_func = lambda wl: 1.5 + 0.1 * wl
+    mat = Material(n=n_func, source=src)
+    assert mat.n == pytest.approx(1.6)
+
+    src.wavelength = 2.0
+    assert mat.n == pytest.approx(1.7)
+
+
+@pytest.mark.unit
+def test_constant_n_material():
+    mat = Material(n=2.0)
+    assert mat.n == pytest.approx(2.0)
+    assert mat.er == pytest.approx(4.0)

--- a/tests/test_tensor_material.py
+++ b/tests/test_tensor_material.py
@@ -4,7 +4,12 @@ Tests for TensorMaterial class - anisotropic materials support
 import pytest
 import numpy as np
 from numpy.testing import assert_allclose, assert_array_equal
+import sys, os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
 from rcwa.model.material import TensorMaterial
+from rcwa.model.layer import Layer
 from rcwa.solve.source import Source
 
 
@@ -157,6 +162,35 @@ class TestTensorMaterial:
         
         with pytest.raises(ValueError, match="Mu tensor must be 3x3"):
             TensorMaterial(mu_tensor=np.ones((2, 3)), source=source)
+
+    def test_n_tensor_constant(self, source):
+        """Create material from refractive index tensor"""
+        n_tensor = np.diag([1.5, 1.6, 1.7])
+        mat = TensorMaterial(n_tensor=n_tensor, source=source)
+        expected_eps = np.diag(np.square([1.5, 1.6, 1.7]))
+        assert_array_equal(mat.epsilon_tensor, expected_eps)
+        assert_array_equal(mat.n_tensor, n_tensor)
+
+    def test_n_tensor_dispersive(self, source):
+        """Dispersive refractive index tensor"""
+        def n_func(wl):
+            return np.diag([1.0 + wl, 1.5 + 0.5*wl, 2.0 + 0.2*wl])
+
+        mat = TensorMaterial(n_tensor=n_func, source=source)
+        source.wavelength = 1.0
+        eps = mat.epsilon_tensor
+        expected = np.diag([(2.0)**2, (2.0)**2, (2.2)**2])
+        assert_allclose(eps, expected)
+
+    def test_no_simplification_in_layer(self, source):
+        """Ensure layer retains full tensor without simplification"""
+        tensor = np.array([[2.0, 0.5, 0.1], [0.5, 3.0, 0.2], [0.1, 0.2, 4.0]], dtype=complex)
+        mat = TensorMaterial(epsilon_tensor=tensor, source=source)
+        layer = Layer(tensor_material=mat, thickness=1.0)
+        layer.set_convolution_matrices(1)
+        conv = layer._tensor_conv_matrices
+        assert 'er_xy' in conv
+        assert_allclose(conv['er_xy'], 0.5 * np.eye(1))
     
     def test_energy_conservation_property(self, source):
         """Test that tensor materials can maintain energy conservation"""


### PR DESCRIPTION
## Summary
- allow Material to accept wavelength-dependent refractive index functions
- support refractive index tensors for TensorMaterial and keep full tensor matrices
- update legacy tests to new API and cover wavelength dependent n/n_tensor

## Testing
- `pytest tests/test_material.py tests/test_tensor_material.py tests/test_anisotropic_integration.py`

------
https://chatgpt.com/codex/tasks/task_e_68b12b5872288327922c7b90e960d821