### PR TITLE
Compute anisotropic flag for PatternedLayer and test tensor P/Q paths

### DIFF
--- a/rcwa/geom/patterned.py
+++ b/rcwa/geom/patterned.py
@@ -67,6 +67,9 @@ class PatternedLayer(Layer):
         self.lattice = lattice
         self.shapes = shapes.copy() if shapes else []
         self.background_material = background_material
+        # Determine if any materials require anisotropic treatment
+        self.is_anisotropic = isinstance(background_material, TensorMaterial) \
+            or any(isinstance(m, TensorMaterial) for _, m in self.shapes)
         self.raster_config = raster_config or RasterConfig()
         self.params = params.copy() if params else {}
         # Track global in-plane rotation (radians) for caching and transforms

--- a/tests/test_patterned_anisotropic_paths.py
+++ b/tests/test_patterned_anisotropic_paths.py
@@ -1,0 +1,42 @@
+import numpy as np
+from unittest.mock import patch
+
+from rcwa.model.material import Material, TensorMaterial
+from rcwa.geom.shape import Rectangle
+from rcwa.geom.patterned import PatternedLayer
+
+
+def test_patterned_layer_tensor_paths():
+    background = Material(er=1.0, ur=1.0)
+    tensor_mat = TensorMaterial(
+        epsilon_tensor=np.diag([2.0, 3.0, 4.0]),
+        mu_tensor=np.eye(3)
+    )
+    rect = Rectangle(center=(0.5, 0.5), width=0.4, height=0.4)
+
+    layer = PatternedLayer(
+        thickness=1.0,
+        lattice=((1.0, 0.0), (0.0, 1.0)),
+        shapes=[(rect, tensor_mat)],
+        background_material=background,
+    )
+
+    assert layer.is_anisotropic is True
+
+    # Provide minimal k-vectors for matrix calculations
+    layer.Kx = 0.0
+    layer.Ky = 0.0
+
+    with patch(
+        "rcwa.core.adapters.LayerTensorAdapter.adapt_P_matrix_for_tensor",
+        return_value=np.zeros((2, 2), dtype=complex),
+    ) as mock_p:
+        layer.P_matrix()
+        assert mock_p.called
+
+    with patch(
+        "rcwa.core.adapters.LayerTensorAdapter.adapt_Q_matrix_for_tensor",
+        return_value=np.zeros((2, 2), dtype=complex),
+    ) as mock_q:
+        layer.Q_matrix()
+        assert mock_q.called


### PR DESCRIPTION
## Summary
- Set `is_anisotropic` based on background and shape materials in `PatternedLayer`
- Add unit test ensuring anisotropic layers invoke tensor-specific P and Q matrix paths

## Testing
- `pytest tests/test_patterned_anisotropic_paths.py::test_patterned_layer_tensor_paths -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3954e09b0832790739b1000338002