### PR TITLE
Support anisotropic multilayer stacks with full tensors

### DIFF
--- a/rcwa/core/matrices.py
+++ b/rcwa/core/matrices.py
@@ -365,13 +365,17 @@ class MatrixCalculator:
             # Handle tensor materials with proper eigensolver
             if hasattr(self, 'is_anisotropic') and self.is_anisotropic:
                 from .adapters import EigensolverTensorAdapter
-                eigenValues, W, Lambda = EigensolverTensorAdapter.solve_tensor_eigenproblem(P, Q)
+                eigenValues, W, Lambda, V_tensor = EigensolverTensorAdapter.solve_tensor_eigenproblem(self, P, Q)
             else:
                 eigenValues, W = eig(OmegaSquared)
                 Lambda = np.diag(sqrt(eigenValues))
-            
+
             LambdaInverse = np.diag(np.reciprocal(np.diag(Lambda)))
-            V = Q @ W @ LambdaInverse
+            if hasattr(self, 'is_anisotropic') and self.is_anisotropic:
+                # Use magnetic eigenvectors provided by the tensor eigensolver
+                V = V_tensor
+            else:
+                V = Q @ W @ LambdaInverse
             X = matrixExponentiate(-Lambda * self.source.k0 * self.thickness)
             return (V, W, Lambda, X)
 


### PR DESCRIPTION
## Summary
- update tensor layer adapters to build full P/Q blocks using all epsilon and mu tensor components
- extend the tensor eigensolver to operate on first-order field blocks and return electric/magnetic eigenvectors
- add regression tests covering isotropic equivalence and energy conservation for full anisotropic multilayer stacks

## Testing
- `pytest tests/test_tensor_solver_integration.py -q`
- `pytest tests/test_half_wave_plate.py -q`
- `pytest tests/test_offdiagonal_anisotropy.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68d3742a5dcc83279a85e5a59456a0ba